### PR TITLE
Acpi v2020.07

### DIFF
--- a/arch/x86/include/asm/arch-tangier/acpi/platform.asl
+++ b/arch/x86/include/asm/arch-tangier/acpi/platform.asl
@@ -22,8 +22,25 @@ Method(_WAK, 1)
     Return (Package() { Zero, Zero })
 }
 
-Scope (_SB)
+Scope (\_SB)
 {
+    /* High Performance Event Timer */
+    Device (HPET)
+    {
+        Name (_HID, EISAID("PNP0103"))
+        Name (_UID, Zero)
+        Name (_CRS, ResourceTemplate()
+        {
+            Memory32Fixed(ReadOnly, 0xFED00000, 0x00000400)
+            Interrupt(ResourceConsumer, Level, ActiveHigh, Exclusive, ,, ) { 8 }
+        })
+
+        Method (_STA)
+        {
+            Return (STA_VISIBLE)
+        }
+    }
+
     /* Real Time Clock */
     Device (RTC0)
     {

--- a/arch/x86/include/asm/arch-tangier/acpi/southcluster.asl
+++ b/arch/x86/include/asm/arch-tangier/acpi/southcluster.asl
@@ -141,6 +141,16 @@ Device (PCI0)
                 Return (STA_VISIBLE)
             }
 
+            Method (_CRS, 0, Serialized)
+            {
+                Name (RBUF, ResourceTemplate()
+                {
+                    GpioInt(Level, ActiveHigh, Exclusive, PullNone, 0,
+                        "\\_SB.PCI0.GPIO", 0, ResourceConsumer, , ) { 64 }
+                })
+                Return (RBUF)
+            }
+
             Method (_RMV, 0, NotSerialized)
             {
                 Return (Zero)

--- a/arch/x86/include/asm/arch-tangier/acpi/southcluster.asl
+++ b/arch/x86/include/asm/arch-tangier/acpi/southcluster.asl
@@ -537,6 +537,20 @@ Device (PCI0)
         {
             Return (RBUF)
         }
+
+        /*
+         * See Documentation/devicetree/bindings/dma/snps-dma.txt
+         * for more information about these bindings.
+         */
+        Name (_DSD, Package () {
+            ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package () {
+                Package () { "dma-channels", 8 },
+                Package () { "dma-masters", 1 },
+                Package () { "snps,block-size", 131071 },
+                Package () { "snps,data-width", Package () { 4 } },
+            }
+        })
     }
 }
 

--- a/cmd/part.c
+++ b/cmd/part.c
@@ -25,6 +25,7 @@
 enum cmd_part_info {
 	CMD_PART_INFO_START = 0,
 	CMD_PART_INFO_SIZE,
+	CMD_PART_INFO_BLOCK,
 	CMD_PART_INFO_NUMBER
 };
 
@@ -151,6 +152,9 @@ static int do_part_info(int argc, char *const argv[], enum cmd_part_info param)
 	case CMD_PART_INFO_SIZE:
 		snprintf(buf, sizeof(buf), LBAF, info.size);
 		break;
+	case CMD_PART_INFO_BLOCK:
+		snprintf(buf, sizeof(buf), LBAF, info.blksz);
+		break;
 	case CMD_PART_INFO_NUMBER:
 		snprintf(buf, sizeof(buf), "0x%x", part);
 		break;
@@ -177,7 +181,12 @@ static int do_part_size(int argc, char *const argv[])
 	return do_part_info(argc, argv, CMD_PART_INFO_SIZE);
 }
 
-static int do_part_number(int argc, char *const argv[])
+static int do_part_block(int argc, char * const argv[])
+{
+	return do_part_info(argc, argv, CMD_PART_INFO_BLOCK);
+}
+
+static int do_part_number(int argc, char * const argv[])
 {
 	return do_part_info(argc, argv, CMD_PART_INFO_NUMBER);
 }
@@ -196,6 +205,8 @@ static int do_part(struct cmd_tbl *cmdtp, int flag, int argc,
 		return do_part_start(argc - 2, argv + 2);
 	else if (!strcmp(argv[1], "size"))
 		return do_part_size(argc - 2, argv + 2);
+	else if (!strcmp(argv[1], "block"))
+		return do_part_block(argc - 2, argv + 2);
 	else if (!strcmp(argv[1], "number"))
 		return do_part_number(argc - 2, argv + 2);
 
@@ -219,6 +230,9 @@ U_BOOT_CMD(
 	"      part can be either partition number or partition name\n"
 	"part size <interface> <dev> <part> <varname>\n"
 	"    - set environment variable to the size of the partition (in blocks)\n"
+	"      part can be either partition number or partition name\n"
+	"part block <interface> <dev> <part> <varname>\n"
+	"    - set environment variable to the size of the partition block\n"
 	"      part can be either partition number or partition name\n"
 	"part number <interface> <dev> <part> <varname>\n"
 	"    - set environment variable to the partition number using the partition name\n"

--- a/doc/README.distro
+++ b/doc/README.distro
@@ -417,3 +417,23 @@ of the boot environment and are not guaranteed to exist or work in the same
 way in future u-boot versions.  In particular the <device type>_boot
 variables (e.g. mmc_boot, usb_boot) are a strictly internal implementation
 detail and must not be used as a public interface.
+
+Using a eMMC partition that has been formatted as a disk by Windows 10
+======================================================================
+
+Let's assume we have an (embedded) board with U-Boot and Linux OS
+installed on eMMC. Linux OS shares one of the eMMC partitions as
+a disk via USB Mass Storage protocol.
+
+It may be useful to utilize that disk to copy bootable files from
+Windows machine to the board in case someone doesn't want to erase
+stock installation on it.
+
+Unfortunately, Windows 10 doesn't provide knobs and always formats
+that disk as a whole, meaning that it creates a partition table on it
+with requested (FAT) partition. As a result U-Boot may not see any
+files on it due to nesting partition tables.
+
+The workaround may be in formatting the partition under Linux OS,
+setting up a network connection between Linux OS and Windows 10 and
+use it to copy files to the partition.


### PR DESCRIPTION
Don't pull this. This is just for reviewing the last patch "adding part command support for block size and partition number" 44d65c37

@razvan-becheriu Your original patch never made it into upstream, now it doesn't apply any more. I fixed it up (and hope it still works), but I think it would be best if you check it, modify the description (short log) and sign it (SoB) as described in [our previous discussion](https://github.com/edison-fw/u-boot/pull/2). And then resend to the mailing list.

You may note that other people already implemented partition number (now returning hex), so I removed that.